### PR TITLE
플레이엑스포 위해서

### DIFF
--- a/RemoveUnity/Assets/Scenes/GameScene.unity
+++ b/RemoveUnity/Assets/Scenes/GameScene.unity
@@ -21620,7 +21620,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2026557222}
-  m_RootOrder: 13
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -50732,7 +50732,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2026557222}
-  m_RootOrder: 14
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -81135,7 +81135,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2026557222}
-  m_RootOrder: 12
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -85893,9 +85893,9 @@ RectTransform:
   - {fileID: 1339954355}
   - {fileID: 695630979}
   - {fileID: 192301611}
-  - {fileID: 1913729106}
   - {fileID: 504682180}
   - {fileID: 1229680147}
+  - {fileID: 1913729106}
   m_Father: {fileID: 137131160}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -87354,8 +87354,8 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
-  m_SortingLayerID: 0
-  m_SortingOrder: 1
+  m_SortingLayerID: 1713156339
+  m_SortingOrder: 3
   m_TargetDisplay: 0
 --- !u!224 &2057847737
 RectTransform:

--- a/RemoveUnity/Assets/Scenes/Infering.unity
+++ b/RemoveUnity/Assets/Scenes/Infering.unity
@@ -9312,8 +9312,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 278585711}
   m_HandleRect: {fileID: 278585709}
   m_Direction: 2
-  m_Value: 0
-  m_Size: 0.8369527
+  m_Value: 1
+  m_Size: 0.83695257
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -11671,8 +11671,8 @@ RectTransform:
   m_Father: {fileID: 1763754058}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.8369528}
+  m_AnchorMin: {x: 0, y: 0.16304743}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -53119,7 +53119,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 101.51001}
+  m_AnchoredPosition: {x: 0, y: 0.00012207031}
   m_SizeDelta: {x: 16.97, y: 622.58}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &1302213917

--- a/RemoveUnity/Assets/Scenes/StoryScene/Phone.unity
+++ b/RemoveUnity/Assets/Scenes/StoryScene/Phone.unity
@@ -730,8 +730,8 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
-  m_SortingLayerID: 0
-  m_SortingOrder: 10
+  m_SortingLayerID: 1713156339
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &127244786
 RectTransform:

--- a/RemoveUnity/Assets/Scenes/StoryScene/StoryEnd.unity
+++ b/RemoveUnity/Assets/Scenes/StoryScene/StoryEnd.unity
@@ -2823,8 +2823,8 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
-  m_SortingLayerID: 0
-  m_SortingOrder: 10
+  m_SortingLayerID: 1713156339
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &2017342143
 RectTransform:

--- a/RemoveUnity/Assets/Scenes/StoryScene/StoryStart.unity
+++ b/RemoveUnity/Assets/Scenes/StoryScene/StoryStart.unity
@@ -1082,8 +1082,8 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
-  m_SortingLayerID: 0
-  m_SortingOrder: 10
+  m_SortingLayerID: 1713156339
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &1194503988
 RectTransform:

--- a/RemoveUnity/Assets/Script/GameManager.cs
+++ b/RemoveUnity/Assets/Script/GameManager.cs
@@ -23,11 +23,19 @@ public class GameManager : MonoBehaviour
     private void Awake()
     {
         Application.targetFrameRate = 60;
+
+        isSkip = true;
+
         if (instance == null)
         {
             instance = this;
             DontDestroyOnLoad(gameObject);
             isScene = new bool[3];
+
+            isScene[0] = true;
+            isScene[1] = true;
+            isScene[2] = true;
+
         }
         else 
             Destroy(gameObject);

--- a/RemoveUnity/Assets/Script/PasswordManager.cs
+++ b/RemoveUnity/Assets/Script/PasswordManager.cs
@@ -28,6 +28,11 @@ public class PasswordManager : MonoBehaviour
     public GameObject error;
     public GameObject PasswordScreen;
     public GameObject ShoutScreen;
+
+    public void Start()
+    {
+        password = "";
+    }
     public void NumberBtnClick()
     {
         switch (number)
@@ -71,6 +76,7 @@ public class PasswordManager : MonoBehaviour
                 {
                     PasswordScreen.SetActive(false);
                     ShoutScreen.SetActive(true);
+                    password = "";
                 }
                 else
                 {

--- a/RemoveUnity/Assets/YarnScript/BeginningInRoom/BeginningInRoom.yarn
+++ b/RemoveUnity/Assets/YarnScript/BeginningInRoom/BeginningInRoom.yarn
@@ -8,7 +8,7 @@ tags:
     <color=yellow>스킵하시겠습니까?</color>
     ->예.
         <<objectDelete HammerBlockImage HammerBlockImage>>
-        <<jump Confusing>>
+        <<jump Select>>
     ->아니오.
 <<endif>>
 <<setNumber 3>>
@@ -141,6 +141,10 @@ title: Confusing
 그렇지만...
 나: 그래도... 기억도 나지 않는 범죄로 잡혀가는 것은 너무 억울해...
 생각이 계속 이어졌다.
+<<jump Select>>
+===
+title: Select
+---
 역시 자수하는 것이 옳을까? 그냥 숨겨버리면 아무도 모르지 않을까?
 -> 자수한다 (지금이라도 늦지 않았다. 경찰에 자초지종을 설명하자!)
     <<jump Surrender>>

--- a/RemoveUnity/ProjectSettings/ProjectSettings.asset
+++ b/RemoveUnity/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 0
     16:9: 1
     Others: 0
-  bundleVersion: 1.21
+  bundleVersion: 1.22
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
1. 다회차 시 joy 앱의 비밀번호가 그대로 남아있는 버그 수정
2. 화장품이 열쇠 위에 있는 버그 수정
3. 원룸 안에서 스킵 시 바로 자수한다. 증거를 없앤다. 선택지가 나오도록 수정
4. skip 버튼 그냥 처음부터 등장해 있도록 수정
5. joy앱의 외치기 부분에서 스크롤이 밑으로 내려가 있는 것 수정
6. 원룸 씬에서 esc보다 대사창이 위 레이어에 있던 것 수정